### PR TITLE
Metatile caching

### DIFF
--- a/env.py
+++ b/env.py
@@ -30,6 +30,7 @@ ERRORLOG = os.environ['ERROR_LOG']
 JPEG_QUALITY = os.environ['JPEG_QUALITY']
 TOPOSM_DEBUG = os.environ['TOPOSM_DEBUG']
 EXTRA_FONTS_DIR = os.environ['EXTRA_FONTS_DIR']
+CACHE_LAYERS = frozenset(os.environ['CACHE_LAYERS'].split(','))
 
 ##### Common constants
 

--- a/env.py
+++ b/env.py
@@ -37,7 +37,9 @@ EXTRA_FONTS_DIR = os.environ['EXTRA_FONTS_DIR']
 #CONTOUR_INTERVAL = 7.62 # 25 ft in meters
 CONTOUR_INTERVAL = 12.192 # 40 ft in meters
 
-MAPNIK_LAYERS = ['hypsorelief', 'landcoverrelief', 'areas', 'ocean', 'contours', 'features']
+AGG_LAYERS = frozenset(['hypsorelief', 'landcoverrelief', 'areas'])
+CAIRO_LAYERS = frozenset(['ocean', 'contours', 'features'])
+MAPNIK_LAYERS = AGG_LAYERS | CAIRO_LAYERS
 
 # Optimal metatile size (N x N subtiles) by zoom level.
 # A too low number is inefficient. A too high number uses

--- a/set-toposm-env.templ
+++ b/set-toposm-env.templ
@@ -42,6 +42,10 @@ export TILE_SIZE=256
 export BORDER_WIDTH=128
 export ERROR_LOG="errors.log"
 
+# Mapnik layers to cache after rendering and reuse as needed.  Comma-separated
+# list.  e.g. CACHE_LAYERS="contours,landcoverrelief"
+export CACHE_LAYERS=""
+
 # Quality setting for combined JPEG layer
 export JPEG_QUALITY=90
 

--- a/toposm.py
+++ b/toposm.py
@@ -164,16 +164,13 @@ def allConstituentTilesExist(z, x, y, ntiles):
 def renderMetaTile(z, x, y, ntiles, maps):
     """Renders the specified map tile and saves the result (including the
     composite) as individual tiles."""
-    hypsorelief = renderLayer('hypsorelief', z, x, y, ntiles, maps['hypsorelief'], 'png')
-    landcoverrelief = renderLayer('landcoverrelief', z, x, y, ntiles, maps['landcoverrelief'], 'png')
-    areas = renderLayer('areas', z, x, y, ntiles, maps['areas'], 'png')
-    ocean = renderLayer('ocean', z, x, y, ntiles, maps['ocean'], 'png')
-    contours = renderLayer('contours', z, x, y, ntiles, maps['contours'], 'png')
-    features = renderLayer('features', z, x, y, ntiles, maps['features'], 'png')
-    base_h = getComposite((hypsorelief, areas, ocean))
-    base_l = getComposite((landcoverrelief, ocean))
-    composite_h = getComposite((base_h, contours, features))
-    composite_l = getComposite((base_l, contours, features))
+    images = {}
+    for layer in MAPNIK_LAYERS:
+        images[layer] = renderLayer(layer, z, x, y, ntiles, maps[layer], 'png')
+    base_h = getComposite((images['hypsorelief'], images['areas'], images['ocean']))
+    base_l = getComposite((images['landcoverrelief'], images['ocean']))
+    composite_h = getComposite((base_h, images['contours'], images['features']))
+    composite_l = getComposite((base_l, images['contours'], images['features']))
     if SAVE_PNG_COMPOSITE:
         saveTiles(z, x, y, ntiles, 'composite_h', composite_h)
         saveTiles(z, x, y, ntiles, 'composite_l', composite_l)
@@ -184,12 +181,8 @@ def renderMetaTile(z, x, y, ntiles, maps):
     if SAVE_INTERMEDIATE_TILES:
         saveTiles(z, x, y, ntiles, 'base_h', base_h)
         saveTiles(z, x, y, ntiles, 'base_l', base_l)
-        saveTiles(z, x, y, ntiles, 'contours', contours)
-        saveTiles(z, x, y, ntiles, 'hypsorelief', hypsorelief)
-        saveTiles(z, x, y, ntiles, 'landcoverrelief', landcoverrelief)
-        saveTiles(z, x, y, ntiles, 'areas', areas)
-        saveTiles(z, x, y, ntiles, 'ocean', ocean)
-        saveTiles(z, x, y, ntiles, 'features', features)
+        for layer in MAPNIK_LAYERS:
+            saveTiles(z, x, y, ntiles, layer, images['layer'])
     
 def renderLayer(name, z, x, y, ntiles, map, suffix = 'png'):
     """Renders the specified map tile (layer) as a mapnik.Image."""

--- a/toposm.py
+++ b/toposm.py
@@ -167,9 +167,9 @@ def renderMetaTile(z, x, y, ntiles, maps):
     hypsorelief = renderLayer('hypsorelief', z, x, y, ntiles, maps['hypsorelief'], 'png')
     landcoverrelief = renderLayer('landcoverrelief', z, x, y, ntiles, maps['landcoverrelief'], 'png')
     areas = renderLayer('areas', z, x, y, ntiles, maps['areas'], 'png')
-    ocean = renderLayer('ocean', z, x, y, ntiles, maps['ocean'], 'png', True)
-    contours = renderLayer('contours', z, x, y, ntiles, maps['contours'], 'png', True)
-    features = renderLayer('features', z, x, y, ntiles, maps['features'], 'png', True)
+    ocean = renderLayer('ocean', z, x, y, ntiles, maps['ocean'], 'png')
+    contours = renderLayer('contours', z, x, y, ntiles, maps['contours'], 'png')
+    features = renderLayer('features', z, x, y, ntiles, maps['features'], 'png')
     base_h = getComposite((hypsorelief, areas, ocean))
     base_l = getComposite((landcoverrelief, ocean))
     composite_h = getComposite((base_h, contours, features))
@@ -191,13 +191,13 @@ def renderMetaTile(z, x, y, ntiles, maps):
         saveTiles(z, x, y, ntiles, 'ocean', ocean)
         saveTiles(z, x, y, ntiles, 'features', features)
     
-def renderLayer(name, z, x, y, ntiles, map, suffix = 'png', useCairo = False):
+def renderLayer(name, z, x, y, ntiles, map, suffix = 'png'):
     """Renders the specified map tile (layer) as a mapnik.Image."""
     console.debugMessage(' Rendering layer: ' + name)
     env = getMercTileEnv(z, x, y, ntiles, True)
     tilesize = getTileSize(ntiles, True)
     map.zoom_to_box(env)
-    if useCairo and USE_CAIRO:
+    if USE_CAIRO and name in CAIRO_LAYERS:
         assert mapnik.has_cairo()
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, tilesize, tilesize)
         mapnik.render(map, surface)

--- a/toposm.py
+++ b/toposm.py
@@ -176,10 +176,12 @@ def renderMetaTile(z, x, y, ntiles, maps):
     images = {}
     for layer in MAPNIK_LAYERS:
         images[layer] = renderLayer(layer, z, x, y, ntiles, maps[layer], 'png')
+    console.debugMessage(' Combining tiles')
     base_h = getComposite((images['hypsorelief'], images['areas'], images['ocean']))
     base_l = getComposite((images['landcoverrelief'], images['ocean']))
     composite_h = getComposite((base_h, images['contours'], images['features']))
     composite_l = getComposite((base_l, images['contours'], images['features']))
+    console.debugMessage(' Saving tiles')
     if SAVE_PNG_COMPOSITE:
         saveTiles(z, x, y, ntiles, 'composite_h', composite_h)
         saveTiles(z, x, y, ntiles, 'composite_l', composite_l)

--- a/toposm.py
+++ b/toposm.py
@@ -98,13 +98,7 @@ class RenderThread:
         if not (allConstituentTilesExist(z, x, y, ntiles)):
             msg = "Rendering meta tile %s %s %s (%sx%s)" % \
                 (z, x, y, ntiles, ntiles)
-            self.runAndLog(msg, renderMetaTile, (z, x, y, ntiles, \
-                self.maps['hypsorelief'], \
-                self.maps['landcoverrelief'], \
-                self.maps['areas'], \
-                self.maps['ocean'], \
-                self.maps['contours'], \
-                self.maps['features']))
+            self.runAndLog(msg, renderMetaTile, (z, x, y, ntiles, self.maps))
 
     def renderLoop(self):
         self.currentz = 0
@@ -167,15 +161,15 @@ def allConstituentTilesExist(z, x, y, ntiles):
             return False
     return True
 
-def renderMetaTile(z, x, y, ntiles, hypsoreliefMap, landcoverreliefMap, areasMap, oceanMap, contoursMap, featuresMap):
+def renderMetaTile(z, x, y, ntiles, maps):
     """Renders the specified map tile and saves the result (including the
     composite) as individual tiles."""
-    hypsorelief = renderLayer('hypsorelief', z, x, y, ntiles, hypsoreliefMap, 'png')
-    landcoverrelief = renderLayer('landcoverrelief', z, x, y, ntiles, landcoverreliefMap, 'png')
-    areas = renderLayer('areas', z, x, y, ntiles, areasMap, 'png')
-    ocean = renderLayer('ocean', z, x, y, ntiles, oceanMap, 'png', True)
-    contours = renderLayer('contours', z, x, y, ntiles, contoursMap, 'png', True)
-    features = renderLayer('features', z, x, y, ntiles, featuresMap, 'png', True)
+    hypsorelief = renderLayer('hypsorelief', z, x, y, ntiles, maps['hypsorelief'], 'png')
+    landcoverrelief = renderLayer('landcoverrelief', z, x, y, ntiles, maps['landcoverrelief'], 'png')
+    areas = renderLayer('areas', z, x, y, ntiles, maps['areas'], 'png')
+    ocean = renderLayer('ocean', z, x, y, ntiles, maps['ocean'], 'png', True)
+    contours = renderLayer('contours', z, x, y, ntiles, maps['contours'], 'png', True)
+    features = renderLayer('features', z, x, y, ntiles, maps['features'], 'png', True)
     base_h = getComposite((hypsorelief, areas, ocean))
     base_l = getComposite((landcoverrelief, ocean))
     composite_h = getComposite((base_h, contours, features))


### PR DESCRIPTION
This branch contains code that allows for caching of metatiles.  I use it to render contour metatiles exactly once, since they're the slowest layer to render and they effectively never change.

This also contains a little reorganization of the layer rendering code.  Rather than listing things explicitly as much, everything's driven from the MAPNIK_LAYERS and CAIRO_LAYERS sets in env.py.
