### PR TITLE
Elevation JPEGs

### DIFF
--- a/prep_toposm_data
+++ b/prep_toposm_data
@@ -39,17 +39,23 @@ for y in `seq $BOTTOM $TOP`; do
 
     # Render and reproject hillshade
     echo "Rendering hillshade..."
+    echo -n "shade: "
     gdaldem hillshade $NEDPATH $HILLSHADE_DIR/$BASE.unproj.tif -z 0.00001
+    echo -n "warp: "
     gdalwarp -t_srs "$SRS900913" -r cubicspline -multi -of GTiff \
         $HILLSHADE_DIR/$BASE.unproj.tif $HILLSHADE_DIR/$BASE.uncomp.tif
     rm $HILLSHADE_DIR/$BASE.unproj.tif
+    echo -n "compress: "
     gdal_translate -of GTiff -co COMPRESS=JPEG \
         $HILLSHADE_DIR/$BASE.uncomp.tif $HILLSHADE_DIR/$BASE.tif
+    echo -n "overview: "
     gdaladdo -r gauss $HILLSHADE_DIR/$BASE.tif 2 4 8 16 32
 
     # Render and reproject colormap
     echo "Rendering colormap..."
+    echo -n "color: "
     gdaldem color-relief $NEDPATH $COLORFILE $COLORMAP_DIR/$BASE.unproj.tif
+    echo -n "warp: "
     gdalwarp -t_srs "$SRS900913" -r cubicspline -multi -of GTiff \
        $COLORMAP_DIR/$BASE.unproj.tif $COLORMAP_DIR/$BASE.uncomp.tif
     rm $COLORMAP_DIR/$BASE.unproj.tif
@@ -60,23 +66,28 @@ for y in `seq $BOTTOM $TOP`; do
     COLORMAP=$COLORMAP_DIR/$BASE.uncomp.tif
     HILLSHADE=$HILLSHADE_DIR/$BASE.uncomp.tif
     # Translate hillshade to PNG+WLD (just to get a valid .wld file)
+    echo -n "world: "
     gdal_translate -of PNG -co WORLDFILE=YES \
         $COLORMAP $HYPSORELIEF_DIR/$BASE.png
     # Create the actual PNG file.  We have to force IM to output RGB, since
     # it'll use a palette if it thinks it can, but JPEG compression only works
     # with RGB images.
+    echo -n "compose: "
     convert $COLORMAP -modulate 120 \
         \( $HILLSHADE -level 70,95% +level 0%,80% \) \
 	-compose screen -composite \
         \( $HILLSHADE -level 0,75% +level 40%,100% \) \
 	-compose multiply -composite \
         -modulate 92 -define png:color-type=2 $HYPSORELIEF_DIR/$BASE.png
+    echo "."
     # PNG+WLD -> GeoTIFF
+    echo -n "compress: "
     gdal_translate -a_srs "$SRS900913" -of GTiff \
        -co COMPRESS=JPEG \
         $HYPSORELIEF_DIR/$BASE.png $HYPSORELIEF_DIR/$BASE.tif
     rm $HYPSORELIEF_DIR/$BASE.png $HYPSORELIEF_DIR/$BASE.png.aux.xml $HYPSORELIEF_DIR/$BASE.wld
     rm $COLORMAP $HILLSHADE
+    echo -n "overview: "
     gdaladdo -r gauss $HYPSORELIEF_DIR/$BASE.tif 2 4 8 16 32
     fi
  

--- a/prep_toposm_data
+++ b/prep_toposm_data
@@ -61,14 +61,16 @@ for y in `seq $BOTTOM $TOP`; do
     HILLSHADE=$HILLSHADE_DIR/$BASE.uncomp.tif
     # Translate hillshade to PNG+WLD (just to get a valid .wld file)
     gdal_translate -of PNG -co WORLDFILE=YES \
-	$COLORMAP_DIR/$BASE.tif $HYPSORELIEF_DIR/$BASE.png 
-    # Create the actual PNG file
+        $COLORMAP $HYPSORELIEF_DIR/$BASE.png
+    # Create the actual PNG file.  We have to force IM to output RGB, since
+    # it'll use a palette if it thinks it can, but JPEG compression only works
+    # with RGB images.
     convert $COLORMAP -modulate 120 \
         \( $HILLSHADE -level 70,95% +level 0%,80% \) \
 	-compose screen -composite \
         \( $HILLSHADE -level 0,75% +level 40%,100% \) \
 	-compose multiply -composite \
-        -modulate 92 $HYPSORELIEF_DIR/$BASE.png
+        -modulate 92 -define png:color-type=2 $HYPSORELIEF_DIR/$BASE.png
     # PNG+WLD -> GeoTIFF
     gdal_translate -a_srs "$SRS900913" -of GTiff \
        -co COMPRESS=JPEG \

--- a/prep_toposm_data
+++ b/prep_toposm_data
@@ -27,37 +27,38 @@ for y in `seq $BOTTOM $TOP`; do
     if [ -f $NEDPATH ] ; then
     echo; echo "***** $NEDPATH"
 
+    if [[ ! -f $HYPSORELIEF_DIR/$BASE.tif ]] ; then
+
     # NOTE: First hillshading, then reprojecting seems to yield a better
     # result than vice versa.
 
+    # NOTE: JPEG compression in the TIFFs saves a lot of disk space, but
+    # ImageMagick doesn't like it.  Thus, we make JPEG-compressed TIFFs
+    # to keep around, but use uncompressed files as inputs to IM and
+    # delete them when we're done.
+
     # Render and reproject hillshade
-    if [[ ! -f $HILLSHADE_DIR/$BASE.tif ]] ; then
     echo "Rendering hillshade..."
     gdaldem hillshade $NEDPATH $HILLSHADE_DIR/$BASE.unproj.tif -z 0.00001
     gdalwarp -t_srs "$SRS900913" -r cubicspline -multi -of GTiff \
-       -co "COMPRESS=DEFLATE" -co "PREDICTOR=2" -co "ZLEVEL=9" \
-       $HILLSHADE_DIR/$BASE.unproj.tif $HILLSHADE_DIR/$BASE.tif
+        $HILLSHADE_DIR/$BASE.unproj.tif $HILLSHADE_DIR/$BASE.uncomp.tif
     rm $HILLSHADE_DIR/$BASE.unproj.tif
+    gdal_translate -of GTiff -co COMPRESS=JPEG \
+        $HILLSHADE_DIR/$BASE.uncomp.tif $HILLSHADE_DIR/$BASE.tif
     gdaladdo -r gauss $HILLSHADE_DIR/$BASE.tif 2 4 8 16 32
-    fi
 
     # Render and reproject colormap
-    if [[ ! -f $COLORMAP_DIR/$BASE.tif ]] ; then
     echo "Rendering colormap..."
     gdaldem color-relief $NEDPATH $COLORFILE $COLORMAP_DIR/$BASE.unproj.tif
     gdalwarp -t_srs "$SRS900913" -r cubicspline -multi -of GTiff \
-       -co "COMPRESS=DEFLATE" -co "PREDICTOR=2" -co "ZLEVEL=9" \
-       $COLORMAP_DIR/$BASE.unproj.tif $COLORMAP_DIR/$BASE.tif
+       $COLORMAP_DIR/$BASE.unproj.tif $COLORMAP_DIR/$BASE.uncomp.tif
     rm $COLORMAP_DIR/$BASE.unproj.tif
-    gdaladdo -r gauss $COLORMAP_DIR/$BASE.tif 2 4 8 16 32
-    fi
  
     # Render hypsorelief (relief shade with hypsometric tinting)
     # (IM strips any georeferencing in the file, so we have to use
     # a world file to put it back)
-    if [[ ! -f $HYPSORELIEF_DIR/$BASE.tif ]] ; then
-    COLORMAP=$COLORMAP_DIR/$BASE.tif
-    HILLSHADE=$HILLSHADE_DIR/$BASE.tif
+    COLORMAP=$COLORMAP_DIR/$BASE.uncomp.tif
+    HILLSHADE=$HILLSHADE_DIR/$BASE.uncomp.tif
     # Translate hillshade to PNG+WLD (just to get a valid .wld file)
     gdal_translate -of PNG -co WORLDFILE=YES \
 	$COLORMAP_DIR/$BASE.tif $HYPSORELIEF_DIR/$BASE.png 
@@ -70,9 +71,10 @@ for y in `seq $BOTTOM $TOP`; do
         -modulate 92 $HYPSORELIEF_DIR/$BASE.png
     # PNG+WLD -> GeoTIFF
     gdal_translate -a_srs "$SRS900913" -of GTiff \
-       -co COMPRESS=DEFLATE -co PREDICTOR=2 -co ZLEVEL=9 \
+       -co COMPRESS=JPEG \
         $HYPSORELIEF_DIR/$BASE.png $HYPSORELIEF_DIR/$BASE.tif
     rm $HYPSORELIEF_DIR/$BASE.png $HYPSORELIEF_DIR/$BASE.png.aux.xml $HYPSORELIEF_DIR/$BASE.wld
+    rm $COLORMAP $HILLSHADE
     gdaladdo -r gauss $HYPSORELIEF_DIR/$BASE.tif 2 4 8 16 32
     fi
  

--- a/prep_toposm_data
+++ b/prep_toposm_data
@@ -95,7 +95,7 @@ for y in `seq $BOTTOM $TOP`; do
 done; done
 
 # generate overviews and VRT layers
-for d in $COLORMAP_DIR $HILLSHADE_DIR $HYPSORELIEF_DIR ; do
+for d in $HILLSHADE_DIR $HYPSORELIEF_DIR ; do
     pushd . ; cd $d
     gdalbuildvrt all.vrt *.tif
     popd

--- a/prep_toposm_data
+++ b/prep_toposm_data
@@ -38,6 +38,7 @@ for y in `seq $BOTTOM $TOP`; do
        -co "COMPRESS=DEFLATE" -co "PREDICTOR=2" -co "ZLEVEL=9" \
        $HILLSHADE_DIR/$BASE.unproj.tif $HILLSHADE_DIR/$BASE.tif
     rm $HILLSHADE_DIR/$BASE.unproj.tif
+    gdaladdo -r gauss $HILLSHADE_DIR/$BASE.tif 2 4 8 16 32
     fi
 
     # Render and reproject colormap
@@ -48,6 +49,7 @@ for y in `seq $BOTTOM $TOP`; do
        -co "COMPRESS=DEFLATE" -co "PREDICTOR=2" -co "ZLEVEL=9" \
        $COLORMAP_DIR/$BASE.unproj.tif $COLORMAP_DIR/$BASE.tif
     rm $COLORMAP_DIR/$BASE.unproj.tif
+    gdaladdo -r gauss $COLORMAP_DIR/$BASE.tif 2 4 8 16 32
     fi
  
     # Render hypsorelief (relief shade with hypsometric tinting)
@@ -71,6 +73,7 @@ for y in `seq $BOTTOM $TOP`; do
        -co COMPRESS=DEFLATE -co PREDICTOR=2 -co ZLEVEL=9 \
         $HYPSORELIEF_DIR/$BASE.png $HYPSORELIEF_DIR/$BASE.tif
     rm $HYPSORELIEF_DIR/$BASE.png $HYPSORELIEF_DIR/$BASE.png.aux.xml $HYPSORELIEF_DIR/$BASE.wld
+    gdaladdo -r gauss $HYPSORELIEF_DIR/$BASE.tif 2 4 8 16 32
     fi
  
     fi;
@@ -79,7 +82,6 @@ done; done
 # generate overviews and VRT layers
 for d in $COLORMAP_DIR $HILLSHADE_DIR $HYPSORELIEF_DIR ; do
     pushd . ; cd $d
-    for f in *.tif ; do gdaladdo -r gauss $f 2 4 8 16 32 ; done
     gdalbuildvrt all.vrt *.tif
     popd
 done


### PR DESCRIPTION
This branch contains changes to prep_toposm_data to store the preprocessed NED GeoTIFFs with JPEG compression.  These files are anywhere from 30% to 10% the size of the DEFLATEd GeoTIFFS.

Mapnik renders the JPEG GeoTIFFs just fine, and I haven't been able to see any quality difference in its output.  ImageMagick won't read them, so the process involves making JPEG-compressed hillshade files for storage and uncompressed hillshade and colormap files for composition.

I also delete the colormap files after using them to generate the hypsorelief files, since they're not used in the rendering process.  That's easy enough to fix if you want to keep them around.
